### PR TITLE
fix FB_unicode

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -77,7 +77,7 @@ void FB_unicode(String &uStr) {
             case 'r': out += '\r'; break;
             case 't': out += '\t'; break;
             case 'u':
-                uBytes = strtol(uStr.c_str() + i + 1, NULL, HEX);
+                uBytes = strtol(uStr.substring(i + 1, i + 5).c_str(), NULL, HEX);
                 i += 4;
                 if ((uBytes >= 0xD800) && (uBytes <= 0xDBFF)) buf = uBytes;
                 else if ((uBytes >= 0xDC00) && (uBytes <= 0xDFFF)) {


### PR DESCRIPTION
FB_unicode неправильно декодирует последовательности символов, когда после русской буквы идёт цифра. Например "Реле1" декодируется в "Рел䍑1".
Вот в чем причина:
Реле1 в unicode escape это \u0420\u0435\u043b\u04351
strtol - обрабатывая 4-й символ, воспринимает его как 04351, а должна должна как 0435


