### PR TITLE
Вкл/выкл превью веб-страниц в сообщениях + FB_formatting 

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ void skipUpdates();                             // пропустить непр
     
 void setTextMode(uint8_t mode);                 // режим текста "для отправки": FB_TEXT, FB_MARKDOWN, FB_HTML (см. пример textMode)
 void notify(bool mode);                         // true/false вкл/выкл уведомления от сообщений бота (по умолч. вкл)
+void webPagePreview(bool mode);                 // true/false вкл/выкл превью веб-страниц в сообщениях (по умолч. вкл)
 void clearServiceMessages(bool state);          // удалять из чата сервисные сообщения о смене названия и закреплении сообщений (умолч. false)
 
 

--- a/README.md
+++ b/README.md
@@ -341,6 +341,17 @@ uint16_t year;          // год
 String timeString();    // строка времени формата ЧЧ:ММ:СС
 String dateString();    // строка даты формата ДД.ММ.ГГГГ
 
+// =========== ФОРМАТИРОВАНИЕ ТЕКСТА ===========
+// структура FB_formatting
+String bold(const String str);                      // Жирный
+String italic(const String str);                    // Курсив
+String underline(const String str);                 // Подчёркнутый
+String strikethrough(const String str);             // Зачёркнутый
+String code(const String str);                      // Код
+String spoiler(const String str);                   // Скрытый
+String link(const String url);                      // Ссылка
+String link(const String url, const String title);  // Ссылка, название
+
 
 // ================ ОБНОВЛЕНИЕ =================
 uint8_t update();       // ОТА обновление прошивки, вызывать внутри обработчика сообщения по флагу OTA
@@ -668,6 +679,28 @@ bot.sendMessage(F("*Bold*, ~Strike~, `code`, [alexgyver.ru](https://alexgyver.ru
 Выведет в чат: **Bold**, ~~Strike~~, `code`, [alexgyver.ru](https://alexgyver.ru/)
 
 > **Внимание!** В режиме FB_MARKDOWN нельзя использовать в сообщениях символы `! + #`, сообщение не отправится. Возможно получится исправить в будущем (проблема urlencode и экранирования зарезервированных символов).
+
+В библиотеке есть структура `FB_formatting`, которая была создана для простоты работы с разметой `FB_HTML` и динамическими переменными.
+Доступные функции:
+```cpp
+  String bold(const String str);                     // Жирный
+  String italic(const String str);                   // Курсив
+  String underline(const String str);                // Подчёркнутый
+  String strikethrough(const String str);            // Зачёркнутый
+  String code(const String str);                     // Код
+  String spoiler(const String str);                  // Скрытый
+  String link(const String url);                     // Ссылка
+  String link(const String url, const String title); // Ссылка, название
+```
+
+Пример:
+```cpp
+FB_formatting f;    // Инициализация
+
+bot.setTextMode(FB_HTML);   // Обязательно устанавливаем разметку `FB_HTML`
+bot.sendMessage(f.bold(f.italic("Угадай число под спойлером: ")) + f.spoiler(String(random())));    // Выводим случайное число в сообщение чата
+```
+Выведет в чат: <b><i>Угадай число под спойлером: </i></b>⠌⡢⢑⠨⠌
 
 <a id="files"></a>
 ## Отправка файлов (v2.20+)

--- a/README_EN.md
+++ b/README_EN.md
@@ -317,6 +317,17 @@ uint16_t year; // year
 StringtimeString(); // time string in HH:MM:SS format
 String dateString(); // date string in DD.MM.YYYY format
 
+// =========== TEXT FORMATTING ===========
+// FB_formatting structure
+String bold(const String str);                      // Bold
+String italic(const String str);                    // Italic
+String underline(const String str);                 // Underline
+String strikethrough(const String str);             // Strikethrough
+String code(const String str);                      // Code
+String spoiler(const String str);                   // Spoiler
+String link(const String url);                      // Link
+String link(const String url, const String title);  // Link, title
+
 
 // ================ UPDATE =================
 uint8_t update(); // OTA firmware update, call inside the message handler on the OTA flag
@@ -657,6 +668,28 @@ bot.sendMessage(F("*Bold*, ~Strike~, `code`, [alexgyver.ru](https://alexgyver.ru
 Output to chat: **Bold**, ~~Strike~~, `code`, [alexgyver.ru](https://alexgyver.ru/)
 
 > **Attention!** In FB_MARKDOWN mode, you cannot use `! + #`, the message will not be sent. It may be possible to fix it in the future (the problem of urlencode and escaping of reserved characters).
+
+The library has a `FB_formatting` structure, which was created for ease of working with the `FB_HTML` markup and dynamic variables.
+Available functions:
+```cpp
+  String bold(const String str);                     // Bold
+  String italic(const String str);                   // Italic
+  String underline(const String str);                // Underline
+  String strikethrough(const String str);            // Strikethrough
+  String code(const String str);                     // Code
+  String spoiler(const String str);                  // Spoiler
+  String link(const String url);                     // Link
+  String link(const String url, const String title); // Link, Title
+```
+
+Example:
+```cpp
+FB_formatting f;    // Initialization
+
+bot.setTextMode(FB_HTML);   // Be sure to install the `FB_HTML` markup
+bot.sendMessage(f.bold(f.italic("Guess the number under the spoiler: ")) + f.spoiler(String(random())));    // Output a random number to the chat message
+```
+Output to chat: <b><i>Guess the number under the spoiler: </i></b>⠌⡢⢑⠨⠌
 
 <a id="files"></a>
 ## Sending files (v2.20+)

--- a/README_EN.md
+++ b/README_EN.md
@@ -118,6 +118,7 @@ void setBufferSizes(uint16_t rx, uint16_t tx); // set buffer sizes for receiving
 
 void setTextMode(uint8_t mode); // text mode "to send": FB_TEXT, FB_MARKDOWN, FB_HTML (see textMode example)
 void notify(bool mode); // true/false enable/disable notifications from bot messages (on by default)
+void webPagePreview(bool mode); // true/false enable/disable link previews for links in messages (on by default)
 void clearServiceMessages(bool state); // remove service messages about changing the name and pinning messages from the chat (default false)
 
 

--- a/examples/textFormatting/textFormatting.ino
+++ b/examples/textFormatting/textFormatting.ino
@@ -1,0 +1,68 @@
+/*
+    Оформление текста с использованием FB_formatting.
+
+    В боте:
+      - Отправляем /start для просмотра работы с динамическими переменными.
+        В данном примере переменная - случайное число (функция random()).
+      - Отправляем любой текст и получаем этот же текст со случайным форматированием.
+*/
+
+
+#define WIFI_SSID "login"
+#define WIFI_PASS "pass"
+#define BOT_TOKEN "2654326546:asjhAsfAsfkllgUsaOuiz_axfkj_AsfkjhB"
+
+#include <FastBot.h>
+FastBot bot(BOT_TOKEN);
+
+FB_formatting f;                            // Инициализация
+
+String format(String input) {
+  switch (random(6)) {
+    case 0: return f.bold(input); break;
+    case 1: return f.italic(input); break;
+    case 2: return f.underline(input); break;
+    case 3: return f.strikethrough(input); break;
+    case 4: return f.spoiler(input); break;
+    case 5: return f.code(input); break;
+    case 6: return f.link("https://alexgyver.ru/", input); break;
+  }
+}
+
+void setup() {
+  connectWiFi();
+
+  bot.setTextMode(FB_HTML);                 // Устанавливаем разметку `FB_HTML`
+  bot.attach(newMsg);
+}
+
+void loop() {
+  bot.tick();
+}
+
+void newMsg (FB_msg& msg){
+  if (msg.text == "/start"){
+  // В чат пишется случайное число со случайным форматированием
+    bot.sendMessage(format(String(random())), msg.chatID);
+  }
+  else {
+    // Пишем ручками любой текст и получаем этот же текст обратно со случайным форматированием
+    bot.replyMessage(format(msg.text), msg.messageID, msg.chatID);
+  }
+}
+
+void connectWiFi() {
+  delay(2000);
+  Serial.begin(115200);
+  Serial.println();
+
+  WiFi.begin(WIFI_SSID, WIFI_PASS);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+    if (millis() > 15000) ESP.restart();
+  }
+  Serial.println("Connected");
+}
+
+

--- a/src/FastBot.h
+++ b/src/FastBot.h
@@ -229,6 +229,11 @@ public:
     void notify(bool mode) {
         notif = mode;
     }
+
+    // true/false вкл/выкл превью веб-страниц в сообщениях (по умолч. вкл)
+    void webPagePreview(bool mode){
+        web_page_preview = mode;
+    }
     
     // ===================== ТИКЕР =====================
     // ручная проверка обновлений
@@ -338,6 +343,7 @@ public:
         req += F("/sendSticker?sticker=");
         req += sid;
         if (!notif) req += F("&disable_notification=true");
+        if (!web_page_preview) req += F("&disable_web_page_preview=true");
         return sendRequest(req, id);
     }
     
@@ -1288,6 +1294,7 @@ private:
     int32_t _lastUsrMsg = 0, _lastBotMsg = 0;
     uint8_t parseMode = 0;
     bool notif = true;
+    bool web_page_preview = true;
     bool clrSrv = false;
     bool ovfFlag = 0;
     int8_t OTAstate = -1;

--- a/src/datatypes.h
+++ b/src/datatypes.h
@@ -148,3 +148,70 @@ struct FB_Time {
         return str;
     }
 };
+
+struct FB_formatting {
+    // Жирный
+    String bold(const String str){
+		String s;
+		s += F("<b>");
+	    s += str;
+		s += F("</b>");
+        return s;
+    }
+ 
+    // Курсив
+    String italic(const String str) {
+		String s;
+		s += F("<i>");
+		s += str;
+		s += F("</i>");
+        return s;
+    }
+ 
+    // Подчёркнутый
+    String underline(const String str) {
+		String s;
+		s += F("<u>");
+		s += str;
+		s += F("</u>");
+        return s;
+    }
+ 
+    // Зачёркнутый
+    String strikethrough(const String str) {
+		String s;
+		s += F("<s>");
+		s += str;
+		s += F("</s>");
+        return s;
+    }
+
+    // Код
+    String code(const String str) {
+		String s;
+		s += F("<code>");
+        s += str;
+		s += F("</code>");
+        return s;
+    }
+
+    // Скрытый
+    String spoiler(const String str) {
+		String s;
+		s += F("<tg-spoiler>");
+		s += str;
+		s += F("</tg-spoiler>");
+        return s;
+    }
+ 
+    // Ссылка
+    String link(const String url, const String label = "") {
+		String s;
+		s += F("<a href=\"");
+        label != "" ? s += label : s += url;
+        s += F("\">");
+        s += url;
+        s += F("</a>");
+        return s;
+    }
+};

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -8,6 +8,7 @@ void FB_escHTML(String& s) {
         case '<': out += F("&lt;"); break;
         case '>': out += F("&gt;"); break;
         case '&': out += F("&amp;"); break;
+        case '"': out += F("&quot;"); break;
         default: out += s[i]; break;
         }
     }


### PR DESCRIPTION
Добавил возможность отключения превью веб-страниц в сообщениях.

Плюс добавил FB_formatting для более удобного форматирования текста в HTML разметке.
Порой отсутствие спецзнаков в Markdown раздражало, а HTML лень каждый раз расписывать типа
`String s = F("<b>") + Sring(Какое-то_значение_которое_меняется_раз_в_минуту) + F("</b>");`
И я подумал почему бы не сделать такой простой инструмент.